### PR TITLE
Onboarding4

### DIFF
--- a/components/onboarding/AddNewField.vue
+++ b/components/onboarding/AddNewField.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="add-new-field">
+    <v-btn
+      variant="outlined"
+      style="display: block; margin-block: 20px; margin-left: auto;"
+      @click="isAddCustomFieldDialogOpen = true"
+    >
+      Add Custom Field +
+    </v-btn>
+
+    <UiConfirmDialog
+      v-model="isAddCustomFieldDialogOpen"
+      title="Add Custom Field"
+      confirm-text="Add Field"
+      cancel-text="Cancel"
+      class="confirm_dialog"
+      max-width="600px"
+      @confirm="addCustomFieldRow(customFieldName)"
+      @cancel="isAddCustomFieldDialogOpen = false"
+    >
+      <v-label class="mb-2">
+        Enter a name of custom field
+      </v-label>
+      <v-text-field
+        v-model="customFieldName"
+        placeholder="Field Name"
+        outlined
+        dense
+        @keydown.enter="addCustomFieldRow(customFieldName)"
+      />
+    </UiConfirmDialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useToastStore } from "~/store/toasts/toast.store";
+import { InputType, type IField } from "~/types/enums/input_type";
+
+
+const toastStore = useToastStore();
+const emit = defineEmits(["addCustomField"]);
+
+
+// Data
+const isAddCustomFieldDialogOpen = ref(false);
+const customFieldName = ref("");
+
+// Computeds
+
+// Methods
+const addCustomFieldRow = (fieldName: string) => {
+  if (!fieldName) {
+    return toastStore.errorToast("Please enter a field name");
+  }
+
+  const customField = {
+    label: fieldName,
+    key: toCamelCase(fieldName),
+    type: InputType.Text,
+    value: "",
+    rules: [formRules.required],
+    isEditable: true,
+    isDeletable: true,
+  } as IField;
+
+  emit("addCustomField", customField);
+  isAddCustomFieldDialogOpen.value = false;
+  customFieldName.value = "";
+
+};
+
+// Watchers
+
+// Lifecycle Hooks
+</script>
+
+<style scoped>
+.add-new-field {
+
+
+}
+</style>

--- a/components/onboarding/AddNewField.vue
+++ b/components/onboarding/AddNewField.vue
@@ -60,7 +60,7 @@ const addCustomFieldRow = (fieldName: string) => {
     value: "",
     rules: [formRules.required],
     isEditable: true,
-    isDeletable: true,
+    isFieldByUser: true,
   } as IField;
 
   emit("addCustomField", customField);

--- a/components/onboarding/InfoFIelds.vue
+++ b/components/onboarding/InfoFIelds.vue
@@ -57,12 +57,23 @@
         </div>
 
       </div>
-      <div v-else>
+      <div v-else class="field_container">
         <UiField
           v-model="field.value"
           :field="field"
           :is-disabled="isStepDisabled"
         />
+        <UiDetailsButton
+          v-if="field.isDeletable"
+          small
+          style="margin-top: 30px;"
+          @click.stop="deleteRow(field)"
+        >
+          <v-icon
+            icon="mdi-delete"
+            color="error"
+          />
+        </UiDetailsButton>
       </div>
     </v-col>
   </div>
@@ -70,6 +81,8 @@
 
 <script setup lang="ts">
 import type { IField } from "~/types/enums/input_type";
+
+const emit = defineEmits(["deleteRow"]);
 
 const props = defineProps({
   fields: {
@@ -89,6 +102,11 @@ const props = defineProps({
 const isStepDisabled = computed(() =>
   props.isFundInitialized && props.step > 1 && props.step < 7,
 )
+
+const deleteRow = (field: IField) => {
+  emit("deleteRow", field);
+}
+
 </script>
 
 <style scoped lang="scss">
@@ -105,6 +123,16 @@ const isStepDisabled = computed(() =>
     display: flex;
     justify-content: flex-end;
     margin-left: auto;
+  }
+}
+
+.field_container{
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+
+  :deep(.field){
+    width: 100%;
   }
 }
 </style>

--- a/components/onboarding/InfoFIelds.vue
+++ b/components/onboarding/InfoFIelds.vue
@@ -64,7 +64,7 @@
           :is-disabled="isStepDisabled"
         />
         <UiDetailsButton
-          v-if="field.isDeletable"
+          v-if="field.isFieldByUser"
           small
           style="margin-top: 30px;"
           @click.stop="deleteRow(field)"

--- a/composables/formatters.ts
+++ b/composables/formatters.ts
@@ -243,3 +243,21 @@ export const formatQuorumPercentage = (
     "N/A",
   )
 };
+
+
+/**
+ *
+ * @param str - string to convert to camel case
+ * @returns string in camel case
+ */
+export const toCamelCase = (str: string) => {
+  return str
+    .toLowerCase()
+    .split(" ")
+    .map((word, index) =>
+      index === 0
+        ? word
+        : word.charAt(0).toUpperCase() + word.slice(1),
+    )
+    .join("");
+}

--- a/pages/create/index.vue
+++ b/pages/create/index.vue
@@ -157,6 +157,13 @@
                 :fields="item.fields"
                 :is-fund-initialized="isFundInitialized"
                 :step="step"
+                @delete-row="deleteCustomFieldRow"
+              />
+
+              <!-- STEP MANAGEMENT -->
+              <OnboardingAddNewField
+                v-if="item.key === OnboardingStep.Management"
+                @add-custom-field="addCustomFieldRow"
               />
 
               <!-- STEP WHITELIST -->
@@ -372,6 +379,53 @@ const isLoadingFetchFundCache = computed(() =>
     ActionState.Loading,
   ),
 );
+
+const deleteCustomFieldRow = (field: IField) => {
+  try{
+    const stepIndex = stepperEntry.value.findIndex(
+      (step) => step.key === OnboardingStep.Management,
+    );
+
+    if (stepIndex !== -1) {
+      const fieldIndex = stepperEntry.value[stepIndex].fields?.findIndex(
+        (f) => f.key === field.key,
+      ) ?? -1;
+
+      if (fieldIndex !== -1) {
+        stepperEntry.value[stepIndex].fields?.splice(fieldIndex, 1);
+      }
+    }
+  }
+  catch (error) {
+    console.error("Error deleting custom field", error);
+    toastStore.errorToast("Error deleting custom field");
+  }
+};
+
+const addCustomFieldRow = (customField: IField) => {
+  try {
+    const managementStepIndex = stepperEntry.value.findIndex(
+      (step) => step.key === OnboardingStep.Management,
+    );
+
+    // check if this key already exists
+    if (managementStepIndex !== -1) {
+      const fieldIndex = stepperEntry.value[managementStepIndex].fields?.findIndex(
+        (f) => f.key === customField.key,
+      );
+
+      if (fieldIndex !== -1) {
+        return toastStore.errorToast("Custom field with this name already exists");
+      }
+
+      stepperEntry.value[managementStepIndex].fields?.push(customField);
+    }
+  } catch (error) {
+    console.error("Error adding custom field", error);
+    toastStore.errorToast("Error adding custom field");
+  }
+
+};
 
 const goToNextStep = () => {
   step.value += 1;

--- a/types/enums/input_type.ts
+++ b/types/enums/input_type.ts
@@ -34,6 +34,7 @@ export interface IField {
   isCustomValueToggleOn?: boolean;
   defaultValue?: any;
   defaultValueInfo?: string;
+  isDeletable?: boolean;
   fields?: IField[];
   title?: string;
   value?: string | boolean;

--- a/types/enums/input_type.ts
+++ b/types/enums/input_type.ts
@@ -34,7 +34,7 @@ export interface IField {
   isCustomValueToggleOn?: boolean;
   defaultValue?: any;
   defaultValueInfo?: string;
-  isDeletable?: boolean;
+  isFieldByUser?: boolean;
   fields?: IField[];
   title?: string;
   value?: string | boolean;

--- a/types/enums/stepper_onboarding.ts
+++ b/types/enums/stepper_onboarding.ts
@@ -105,10 +105,8 @@ const OnboardingFieldsMap: FieldsMapType = {
   [OnboardingStep.Management]: (FundSettingsStepFieldsMap[StepSections.Management] as IField[]).map(
     (field: IField) => {
 
-
       // override for minLiquidAssetShare
       if(field.key === "minLiquidAssetShare") {
-
         return {
           ...field,
           isEditable: true,


### PR DESCRIPTION
### TODO 

- [ ] show 2 steps modal when storing NAV -- 1) store nav 2) allow manager to update NAV  (@lukatavcer)
- [x] add custom metadata fields to the management (@lux-v)
- [ ] clear local storage for fund create data if there is already some fund init cache present
- [ ] if chain changes after fund cache was fetched already, clear the stepperEntry (only if chain changes)
- [ ] Permissions.vue if you check any toggle switch, add these 2 permissions to the actual list of permissions on the left
- [ ] handle  `getFundInitializationCache` if for example baseToken is wrong, everything gets stuck... but there should be a warning


### IN QUESTION TODO
- [ ] save permissions to local storage (better not, as state is not synced)
- [ ] save NAV methods to local storage (and take care of merging them with those that are fetched in getNAVData)



### STYLE
- rename onboarding to FundCreate

### TO TEST
- test if NAV proposals work as intended