### PR TITLE
Onboarding5

### DIFF
--- a/components/global/ui/Field.vue
+++ b/components/global/ui/Field.vue
@@ -62,6 +62,7 @@
             :is-disabled="isInputDisabled"
             :is-preview="isPreview"
             :custom-error-message="customErrorMessage"
+            :chain-id="chainId"
           />
         </div>
       </template>
@@ -78,6 +79,7 @@
               :is-disabled="isInputDisabled"
               :is-preview="isPreview"
               :custom-error-message="customErrorMessage"
+              :chain-id="chainId"
             />
           </template>
         </div>
@@ -95,6 +97,7 @@
         :is-disabled="isInputDisabled"
         :is-preview="isPreview"
         :custom-error-message="customErrorMessage"
+        :chain-id="chainId"
       />
     </template>
 
@@ -110,6 +113,11 @@ import InfoBox from "./InfoBox.vue";
 const emit = defineEmits(["update:modelValue", "update:isCustomValueToggleOn", "update:defaultValue"]);
 
 const props = defineProps({
+  // chainId is required for time to blocks component
+  chainId: {
+    type: String,
+    default: "",
+  },
   field: {
     type: Object as PropType<any>,
     default: () => ({}),

--- a/components/global/ui/FieldInput.vue
+++ b/components/global/ui/FieldInput.vue
@@ -60,11 +60,21 @@
         />
       </div>
     </template>
+    <template v-else-if="field.type === InputType.Period">
+      <UiTimeToBlocks
+        v-model="value"
+        :rules="field.rules"
+        :placeholder="field.placeholder"
+        :disabled="isDisabled"
+        :error-messages="errorMessages"
+        :chain-id="chainId"
+      />
+    </template>
+
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
 import { InputType } from "~/types/enums/input_type";
 
 const props = defineProps({
@@ -85,6 +95,10 @@ const props = defineProps({
     default: false,
   },
   customErrorMessage: {
+    type: String,
+    default: "",
+  },
+  chainId: {
     type: String,
     default: "",
   },

--- a/components/global/ui/TimeToBlocks.vue
+++ b/components/global/ui/TimeToBlocks.vue
@@ -1,0 +1,145 @@
+<template>
+  <v-row class="time-to-blocks">
+    <v-col cols="10">
+      <v-text-field
+        v-model="inputValue"
+        type="number"
+        :placeholder="placeholder"
+        :disabled="isDisabled"
+        :rules="rules"
+        :error-messages="customErrorMessage"
+      />
+    </v-col>
+    <v-col cols="2">
+      <v-select
+        v-model="selectedUnit"
+        :items="periodChoices"
+        class="field-select"
+        :disabled="isDisabled"
+      />
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { useWeb3Store } from "~/store/web3/web3.store";
+import { periodChoices, PeriodUnits, TimeInSeconds } from "~/types/enums/input_type";
+
+const CHAIN_ID_MAP = {
+  "0xa4b1": "0x1",
+} as const;
+
+
+const emit = defineEmits(["update:modelValue", "update:blocks"]);
+
+const { initializeBlockTimeContext } = useBlockTime();
+const web3Store = useWeb3Store();
+
+const props = defineProps({
+  modelValue: {
+    type: Number,
+    default: 0,
+  },
+  chainId: {
+    type: String,
+    default: "",
+  },
+  placeholder: {
+    type: String,
+    default: "",
+  },
+  isDisabled: {
+    type: Boolean,
+    default: false,
+  },
+  customErrorMessage: {
+    type: String,
+    default: "",
+  },
+  rules: {
+    type: Array as PropType<string[]>,
+    default: () => [],
+  },
+});
+
+// we only save the number in blocks and have a local state for the unit which is changing and emiting the blocks
+const inputValue = ref(props.modelValue);
+const selectedUnit = ref<PeriodUnits>(PeriodUnits.Days);
+const blockTime = ref(0);
+
+const blocks = computed(() => {
+  const timeInSeconds = TimeInSeconds[selectedUnit.value];
+  const output =  Math.floor((inputValue.value * timeInSeconds) / blockTime.value);
+
+  return output;
+});
+
+const getWeb3Instance = () => {
+  const mappedChainId = CHAIN_ID_MAP[props.chainId as keyof typeof CHAIN_ID_MAP];
+
+  // ARB1 is mapped to ETH
+  if(mappedChainId) {
+    return web3Store.chainProviders[mappedChainId];
+  }
+
+  return web3Store.chainProviders[props.chainId];
+};
+
+const determineInputValueAndUnit = (totalSeconds: number) => {
+  let bestUnit: PeriodUnits = PeriodUnits.Seconds;
+  let bestValue = totalSeconds;
+
+  for (const unit of Object.keys(TimeInSeconds) as PeriodUnits[]) {
+    const secondsPerUnit = TimeInSeconds[unit];
+    const value = totalSeconds / secondsPerUnit;
+
+    if (value >= 1 && value < bestValue) {
+      bestValue = value;
+      bestUnit = unit;
+    }
+  }
+
+  return { bestValue, bestUnit };
+};
+
+const initializeBlockTime = async () => {
+  const web3Instance = getWeb3Instance();
+  if (!web3Instance) return;
+  const context = await initializeBlockTimeContext(web3Instance);
+  blockTime.value = context?.averageBlockTime || 0;
+
+
+  if (blockTime.value > 0 && props.modelValue > 0) {
+    const totalSeconds = props.modelValue * blockTime.value;
+    const { bestValue, bestUnit } = determineInputValueAndUnit(totalSeconds);
+    inputValue.value = bestValue;
+    selectedUnit.value = bestUnit;
+  } else {
+    inputValue.value = 0;
+    selectedUnit.value = PeriodUnits.Days;
+  }
+};
+
+onMounted(initializeBlockTime);
+
+watch([inputValue, selectedUnit], () => {
+  console.log("blocks: ", blocks.value);
+  emit("update:modelValue", blocks.value);
+});
+</script>
+
+<style scoped lang="scss">
+.time-to-blocks {
+  display: flex;
+  align-items: center;
+}
+
+.field-select {
+  line-height: normal;
+
+  :deep(.v-field__input) {
+    padding: 10px;
+    min-height: 40px;
+  }
+}
+</style>

--- a/components/onboarding/InfoFIelds.vue
+++ b/components/onboarding/InfoFIelds.vue
@@ -17,6 +17,7 @@
             v-model="subField.value"
             :field="subField"
             :is-disabled="!field.isToggleOn || isStepDisabled"
+            :chain-id="chainId"
           />
         </template>
       </UiFieldsGroup>
@@ -30,6 +31,7 @@
           :is-disabled="isStepDisabled"
           :custom-error-message="getCustomFieldErrorMessage(field)"
           :show-default-value-info="!isFundInitialized"
+          :chain-id="chainId"
         />
 
         <div
@@ -41,12 +43,14 @@
             class="base_token_data__input"
             :field="baseTokenSymbolField"
             :is-disabled="true"
+            :chain-id="chainId"
           />
           <UiField
             v-model:model-value="baseTokenDecimals"
             class="base_token_data__input"
             :field="baseTokenDecimalsField"
             :is-disabled="true"
+            :chain-id="chainId"
           />
         </div>
         <UiDetailsButton
@@ -78,6 +82,10 @@ const { fundChainId, fundChainName } = storeToRefs(createFundStore);
 const emit = defineEmits(["deleteRow"]);
 
 const props = defineProps({
+  chainId: {
+    type: String,
+    default: "",
+  },
   fields: {
     type: Array as () => IField[],
     default: () => [],

--- a/pages/create/index.vue
+++ b/pages/create/index.vue
@@ -146,6 +146,7 @@
                 :fields="item.fields"
                 :is-fund-initialized="isFundInitialized"
                 :step="step"
+                :chain-id="selectedChainId"
                 @delete-row="(e) => deleteCustomFieldRow(e, item.key)"
               />
 

--- a/types/enums/fund_setting_proposal.ts
+++ b/types/enums/fund_setting_proposal.ts
@@ -1,5 +1,5 @@
 import type { IField, IFieldGroup } from "~/types/enums/input_type";
-import { InputType } from "~/types/enums/input_type";
+import { InputType, periodChoices } from "~/types/enums/input_type";
 
 export enum ProposalStep {
   Setup = "setup",
@@ -292,9 +292,10 @@ export const FundSettingsStepFieldsMap: FieldsMapType = {
   ],
   [StepSections.Management]: [
     {
-      label: "Planned Settlement Period (Days)",
+      label: "Planned Settlement Period",
       key: "plannedSettlementPeriod",
-      type: InputType.Number,
+      type: InputType.Period,
+      choices: periodChoices,
       placeholder: "E.g. 0",
       rules: [formRules.required, formRules.isNonNegativeNumber],
       isEditable: true,

--- a/types/enums/input_type.ts
+++ b/types/enums/input_type.ts
@@ -5,7 +5,35 @@ export enum InputType {
   Number = "number",
   Select = "select",
   Image = "image",
+  Period = "period",
+  Date = "date",
 }
+
+export enum PeriodUnits {
+  Seconds = "seconds",
+  Minutes = "minutes",
+  Hours = "hours",
+  Days = "days",
+  Weeks = "weeks",
+}
+
+type TimeInSecondsMap = Record<PeriodUnits, number>;
+
+
+export const TimeInSeconds: TimeInSecondsMap = {
+  [PeriodUnits.Seconds]: 1,
+  [PeriodUnits.Minutes]: 60,
+  [PeriodUnits.Hours]: 3600,
+  [PeriodUnits.Days]: 86400,
+  [PeriodUnits.Weeks]: 604800,
+};
+export const periodChoices = [
+  { value: PeriodUnits.Seconds, title: "Seconds" },
+  { value: PeriodUnits.Minutes, title: "Minutes" },
+  { value: PeriodUnits.Hours, title: "Hours" },
+  { value: PeriodUnits.Days, title: "Days" },
+  { value: PeriodUnits.Weeks, title: "Weeks" },
+]
 
 export const defaultInputTypeValue: Record<InputType, any> = {
   [InputType.Text]: "",
@@ -16,6 +44,8 @@ export const defaultInputTypeValue: Record<InputType, any> = {
   // wherever we will need them.
   [InputType.Select]: 0,
   [InputType.Image]: "",
+  [InputType.Period]: 0,
+  [InputType.Date]: "",
 }
 
 export interface IField {


### PR DESCRIPTION
### TODO

- [x] handle  `getFundInitializationCache` if for example baseToken is wrong, everything gets stuck... but there should be a warning (@lukatavcer)
- [ ]  a select dropdown (seconds, minutes, hours, days, weeks) --> create a new UI component for this where the input value is number value and then it emits blocks based on the selected value, so that it can be used in multiple places
  - **IMPORTANT**: on ARB1 it should take block time from the L1 ETHEREUM
![image](https://github.com/user-attachments/assets/78e50126-f365-4e7b-a520-992aa635cc49)
- [x] move custom fields from management to basic info tab


### IN QUESTION TODO
- [ ] Permissions.vue if you check any toggle switch, add these 2 permissions to the actual list of permissions on the left 
- [ ] save NAV methods to local storage (and take care of merging them with those that are fetched in getNAVData)



### STYLE
- rename onboarding to FundCreate